### PR TITLE
fix the has and belong to many relationship in the case of accounts,country and currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ curl -XGET -v -H 'Content-Type: application/json' -H 'access-token: lW1c60hYkRwA
 | ------------------------ | ------------------------------- | ------ | ---------------- |
 | POST api/v1/auth/sign_in | Login a user                    | OK     | ALL              |
 | POST api/v1/auth/        | Register a user                 | OK     | ALL              |
-| GET api/v1/user_accounts | Returns a list of User Accounts | OK     | Admin or contrib |
+| GET api/v1/user_accounts | Returns a list of User Accounts | OK     | investor user |
 | GET api/v1/accounts      | Returns a list of accounts      |
 | POST api/v1/accounts     | Create a new accounts           |
 | GET api/v1/currencies    | Returns a list of Currencies    |

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,34 +1,35 @@
 class Account < ApplicationRecord
- belongs_to :country
- belongs_to :currency
+#  belongs_to :country
+#  belongs_to :currency
+belongs_to :platform
 
- validates :country_id , presence: true
- validates :currency_id , presence: true
- before_save :check_country_array
- before_save :check_currency_array
+#  validates :country_id , presence: true
+#  validates :currency_id , presence: true
+#  before_save :check_country_array
+#  before_save :check_currency_array
 
 
-  def check_country_array
-    begin
-    if Country.where("id in(?)", self.country_id).count == self.country_id.size
-      puts "same size"
-    else
-      errors.add(:country_id, :blank, message: "Some Country ID not found !")
-    end
-    rescue ActiveRecord::StatementInvalid => e
-      errors.add(:country_id, :blank, message: "Some Country ID not found !")
-      end
-  end
+  # def check_country_array
+  #   begin
+  #   if Country.where("id in(?)", self.country_id).count == self.country_id.size
+  #     puts "same size"
+  #   else
+  #     errors.add(:country_id, :blank, message: "Some Country ID not found !")
+  #   end
+  #   rescue ActiveRecord::StatementInvalid => e
+  #     errors.add(:country_id, :blank, message: "Some Country ID not found !")
+  #     end
+  # end
 
-  def check_currency_array
-    begin
-    if Currency.where("id in(?)", self.currency_id).count == self.currency_id.size
-      puts "same size"
-    else
-      errors.add(:currency_id, :blank, message: "Some Currency ID not found !")
-    end
-    rescue ActiveRecord::StatementInvalid => e
-      errors.add(:currency_id, :blank, message: "Some Country ID not found !")
-    end
-  end
+  # def check_currency_array
+  #   begin
+  #   if Currency.where("id in(?)", self.currency_id).count == self.currency_id.size
+  #     puts "same size"
+  #   else
+  #     errors.add(:currency_id, :blank, message: "Some Currency ID not found !")
+  #   end
+  #   rescue ActiveRecord::StatementInvalid => e
+  #     errors.add(:currency_id, :blank, message: "Some Country ID not found !")
+  #   end
+  # end
 end

--- a/app/models/platform.rb
+++ b/app/models/platform.rb
@@ -4,4 +4,5 @@ class Platform < ApplicationRecord
    has_many :user_platforms
    has_many :loans
    has_many :user_loans
+   has_many :accounts
 end

--- a/db/migrate/20201215152127_change_account_cols_to_array.rb
+++ b/db/migrate/20201215152127_change_account_cols_to_array.rb
@@ -1,0 +1,11 @@
+class ChangeAccountColsToArray < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :accounts, :country_id
+    remove_column :accounts, :currency_id
+
+   
+
+    add_column :accounts, :country_id, :json
+    add_column :accounts, :currency_id, :json
+  end
+end

--- a/db/migrate/20201215175730_change_account_cols_to_jsonb.rb
+++ b/db/migrate/20201215175730_change_account_cols_to_jsonb.rb
@@ -1,0 +1,11 @@
+class ChangeAccountColsToJsonb < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :accounts, :country_id
+    remove_column :accounts, :currency_id
+
+   
+
+    add_column :accounts, :country_id, :jsonb, default: {} 
+    add_column :accounts, :currency_id, :jsonb, default: {} 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_14_155515) do
+ActiveRecord::Schema.define(version: 2020_12_15_175730) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -23,8 +23,8 @@ ActiveRecord::Schema.define(version: 2020_12_14_155515) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "platform_id"
-    t.uuid "country_id"
-    t.uuid "currency_id"
+    t.jsonb "country_id", default: {}
+    t.jsonb "currency_id", default: {}
     t.index ["platform_id"], name: "index_accounts_on_platform_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -77,29 +77,25 @@ user_contrib.save
   normal_user.save
 end
 
-# create a currency 
+# create a number of currencies
+# will assume the name and play with ramdon data
+1.upto(4) do |i|
 currency = Currency.find_or_create_by(
-    id: '973ed305-2840-4993-8c59-d4f8a78c02b1',
-    name: 'dollar',
-    code: 'USD',
+    id: "973ed30#{i}-2840-499#{i+1}-8c59-d4f8a78c0#{i+2}b1",
+    name: "dollar-#{i}",
+    code: "USD#{i}",
     decimal_places: 2,
-    symbol: '$',
+    symbol: "$#{i}",
     fx_eur: 1.126
 )
-
-# create the country which the currecy belong to
+# create a number of country which the currecy belong to
 country = Country.find_or_create_by(
-    name: 'UNITED STATES OF AMERICA',
-    iso_code: 'US',
-    currency_id: currency.id
+  name: "UNITED STATES OF AMERICA-#{i}",
+  iso_code: "US-#{i}",
+  currency_id: currency.id
 )
+end
 
-# an account has a currecy and county
-Account.find_or_create_by(
-    name: 'Test',
-    country_id: country.id,
-    currency_id: currency.id
-)
 
 1.upto(20) do |i|
   Platform.find_or_create_by({
@@ -126,28 +122,66 @@ Account.find_or_create_by(
                        :logo => "contact_id"
                    })
 end
-#
-1.upto(20) do |i|
-  user = User.order("RANDOM()").first.id
-  UserAccount.find_or_create_by({
-                          :country_id => Country.order("RANDOM()").first.id,
-                          :account_id => Account.order("RANDOM()").first.id,
-                          :platform_id => Platform.order("RANDOM()").first.id,
-                          :currency_id => Currency.order("RANDOM()").first.id,
-                          :user_id => user,
-                          :category => "Category {i}",
-                          :name => "User Account Name #{i}",
-                          :total_fee => rand(0..100),
-                          :total_loss => rand(0..100),
-                          :total_tax => rand(0..10),
-                          :active => true,
-                          :total_invest => rand(0..100),
-                          :total_profit => rand(0..100),
-                          :total_referral => rand(0..100),
-                          :total_interest => rand(0..100),
-                          :total_bonus => rand(0..100)
-                      })
-  end
+# an number of account with a platform,currecy and county
+# def countries 
+#   country_ids  = {}
+#   country_ids[:countries] = []
+#   1.upto(5) do |i|
+#     country_ids[:countries] << Country.order("RANDOM()").first.id
+#   end
+#   return country_ids
+# end
+# def currecies 
+#   currency_ids = {}
+#   currency_ids[:currecies] = []
+#   1.upto(5) do |i|
+#     currency_ids[:currecies] << Currency.order("RANDOM()").first.id
+#   end
+#   return currency_ids
+# end
+
+country_ids = ["c793f2f6-30d3-4f4e-8577-9c72b018a0d3","c793f2f6-30d3-4f4e-8577-9c72b018a0d3","33faa2a8-1bc4-4668-9481-cd7af673894c","213e25df-485a-4b45-bbbc-28b2def50091","c793f2f6-30d3-4f4e-8577-9c72b018a0d3"]
+currency_ids = ["213e25df-485a-4b45-bbbc-28b2def50091","213e25df-485a-4b45-bbbc-28b2def50091","810ed094-b408-46e7-898e-bf0235ca97f0","213e25df-485a-4b45-bbbc-28b2def50091","213e25df-485a-4b45-bbbc-28b2def50091"]
+1.upto(10) do |i|
+
+  a = Account.new
+  a.name = "paypal-#{i}"
+  a.category = "category#{i}"
+ 
+
+  a.country_id[:countries] = []
+  a.currency_id[:currencies] = []
+  a.country_id[:countries].push(country_ids)
+  a.currency_id[:currencies].push(currency_ids)
+  a.platform_id = Platform.order("RANDOM()").first.id
+  p a
+  a.save!
+
+end
+
+
+# # the normal user or the investor
+# 1.upto(20) do |i|
+#   user = User.order("RANDOM()").first.id
+#   UserAccount.find_or_create_by({
+#                           :country_id => Country.order("RANDOM()").first.id,
+#                           :account_id => Account.order("RANDOM()").first.id,
+#                           :platform_id => Platform.order("RANDOM()").first.id,
+#                           :currency_id => Currency.order("RANDOM()").first.id,
+#                           :user_id => user,
+#                           :category => "Category {i}",
+#                           :name => "User Account Name #{i}",
+#                           :total_fee => rand(0..100),
+#                           :total_loss => rand(0..100),
+#                           :total_tax => rand(0..10),
+#                           :active => true,
+#                           :total_invest => rand(0..100),
+#                           :total_profit => rand(0..100),
+#                           :total_referral => rand(0..100),
+#                           :total_interest => rand(0..100),
+#                           :total_bonus => rand(0..100)
+#                       })
+#   end
 
   # Originator.delete_all
   # 1.upto(20) do |i|
@@ -257,7 +291,7 @@ end
 #   # end
 #
 # end
-# p '=============== Done! ==============='
+p '=============== Done! ==============='
 #
 #
 #


### PR DESCRIPTION
#### What does this PR do?
Make changes to the account table to allow an array on countries and currencies. 
#### Description of Task to be completed?
- [x] Make country_id and currency_id to jsonb
- [x] Remove the check_country_array and check_currency_array validators as they are not needed anymore.
- [x] implement a proper working seed for account table
#### How should this be manually tested? -if you can
run the seed file or use rails console
#### Any background context you want to provide?
Unlike in the past where an account had just one country and currency, now an account have as many currencies and countries it want . For example, an account like paypal, can have many countries and many currencies. see below:
`<Account id: "2d7143d5-f655-45fd-9b5d-35949f6cc136", category: "category2", name: "paypal-2", icon: nil, created_at: "2020-12-15 18:04:45", updated_at: "2020-12-15 18:04:45", platform_id: "9ad479dd-8118-44e2-b120-6f5735ee67ce", country_id: {"countries"=>[["c793f2f6-30d3-4f4e-8577-9c72b018a0d3", "c793f2f6-30d3-4f4e-8577-9c72b018a0d3", "33faa2a8-1bc4-4668-9481-cd7af673894c", "213e25df-485a-4b45-bbbc-28b2def50091", "c793f2f6-30d3-4f4e-8577-9c72b018a0d3"]]}, currency_id: {"currencies"=>[["213e25df-485a-4b45-bbbc-28b2def50091", "213e25df-485a-4b45-bbbc-28b2def50091", "810ed094-b408-46e7-898e-bf0235ca97f0", "213e25df-485a-4b45-bbbc-28b2def50091", "213e25df-485a-4b45-bbbc-28b2def50091"]]}`>