### PR TITLE
Remove 'Unwanted' Hirb dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,6 @@ group :development, :test do
   gem 'rubocop', '~> 1.8', require: false
 
   # YARD is a documentation generation tool for the Ruby programming language.
-  gem 'hirb', '~> 0.7.3'
   gem 'yard'
 
   # Sajjad installed this gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,6 @@ GEM
     ffi (1.14.2-x86-mingw32)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    hirb (0.7.3)
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.1)
@@ -284,7 +283,6 @@ DEPENDENCIES
   capybara (>= 2.15)
   devise_token_auth
   dotenv-rails (~> 2.7.6)
-  hirb (~> 0.7.3)
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)


### PR DESCRIPTION
In this PR:
 - [x] Removed the `Hirb` gem from the list of dependenciess