### PR TITLE
Remove icons and logos in the migration fields for platforms

### DIFF
--- a/db/migrate/20201221153057_remove_icon_logo_from_platforms.rb
+++ b/db/migrate/20201221153057_remove_icon_logo_from_platforms.rb
@@ -1,7 +1,7 @@
 class RemoveIconLogoFromPlatforms < ActiveRecord::Migration[6.0]
   def change
-    # remove_column :platforms, :icon
-    # remove_column :platforms, :logo
+    remove_column :platforms, :icon
+    remove_column :platforms, :logo
 
     add_column :platforms, :sm_notes, :string
   


### PR DESCRIPTION
This PR:
- [x] Removes the Icons and Logos fields in the `platforms` migrations.